### PR TITLE
Fix NPE when replacing label

### DIFF
--- a/src/main/java/com/koyomiji/asmine/query/CodeFragmentQuery.java
+++ b/src/main/java/com/koyomiji/asmine/query/CodeFragmentQuery.java
@@ -8,6 +8,7 @@ import com.koyomiji.asmine.stencil.StencilEvaluationException;
 import com.koyomiji.asmine.stencil.insn.AbstractInsnStencil;
 import com.koyomiji.asmine.tree.AbstractInsnNodeHelper;
 import com.koyomiji.asmine.tuple.Pair;
+import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.InsnList;
 
 import java.util.ArrayList;
@@ -51,8 +52,8 @@ public class CodeFragmentQuery<T> extends AbstractQuery<T> {
     this.selected = selected;
   }
 
-  private InsnList instantiate(List<AbstractInsnStencil> insns) throws StencilEvaluationException {
-    InsnList insnList = new InsnList();
+  private List<AbstractInsnNode> instantiate(List<AbstractInsnStencil> insns) throws StencilEvaluationException {
+    List<AbstractInsnNode> insnList = new ArrayList<>();
 
     for (AbstractInsnStencil insn : insns) {
       insnList.add(insn.evaluate(matchResult));

--- a/src/test/java/com/koyomiji/asmine/test/MethodQueryTest.java
+++ b/src/test/java/com/koyomiji/asmine/test/MethodQueryTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.tree.FrameNode;
 import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.MethodNode;
 
 public class MethodQueryTest {
@@ -847,5 +848,35 @@ public class MethodQueryTest {
 
     Assertions.assertEquals(ArrayListHelper.of(Opcodes.LONG, Opcodes.INTEGER), ((FrameNode) mn.instructions.get(1)).stack);
     Assertions.assertEquals(ArrayListHelper.of(Opcodes.LONG, Opcodes.INTEGER), ((FrameNode) mn.instructions.get(1)).local);
+  }
+
+  @Test
+  void test_18() {
+    LabelNode l0 = null, l1 = null;
+
+    MethodNode mn = MethodQuery.ofNew()
+            .addInsns(
+                    l0 = Insns.label(),
+                    Insns.return_(),
+                    l1 = Insns.label()
+            )
+            .selectCodeFragment(
+                    Regexes.concatenate(
+                            CodeRegexes.stencil(InsnStencils.label(Stencils.bind(0))),
+                            CodeRegexes.stencil(InsnStencils.return_()),
+                            CodeRegexes.stencil(InsnStencils.label(Stencils.bind(1)))
+                    )
+            )
+            .replaceWith(
+                    InsnStencils.label(Stencils.bound(0)),
+                    InsnStencils.ireturn(),
+                    InsnStencils.label(Stencils.bound(1))
+            )
+            .done()
+            .done();
+
+    Assertions.assertEquals(l0, mn.instructions.get(0));
+    Assertions.assertEquals(Opcodes.IRETURN, mn.instructions.get(1).getOpcode());
+    Assertions.assertEquals(l1, mn.instructions.get(2));
   }
 }


### PR DESCRIPTION
CodeFragmentQuery.instantiate should avoid using InsnList, because if an instruction is already in InsnList, inserting it into another InsnList breaks the former InsnList.